### PR TITLE
2019-01-15 12:50 UTC+0100 Aleksander Czajczynski (hb fki.pl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1771,33 +1771,34 @@ Supported shells per host platforms:
 * Libraries:
 
      * HB_WITH_ADS - Advantage Client Engine API [win, linux, free, closed-source]
-        * <http://www.sybase.com/products/databasemanagement/advantagedatabaseserver/client-engine-api>
+        * <https://devzone.advantagedatabase.com/dz/content.aspx?key=20&Release=19&Product=5>
      * HB_WITH_ALLEGRO - Allegro (GUI) [multiplatform, free, open-source]
         * <http://alleg.sourceforge.net/>
      * HB_WITH_BLAT - Blat (SMTP client) [win, free, open-source]
-        * <http://www.blat.net/>
+        * <https://www.blat.net/>
      * HB_WITH_BZIP2 - libbzip2 [multiplatform, free, open-source]
         * <http://www.bzip.org/>
      * HB_WITH_CAIRO - Cairo [multiplatform, open-source]
-        * <http://www.gtk.org/download/win32.php><br />
-        Look for these components on page above: cairo-dev_*_win32.zip, cairo_*_win32.zip, libpng_*_win32.zip
+        * <https://www.gtk.org/download/windows.php><br />
+        GTK for Windows has a side effect of including a build of Cairo libs.
+        After installation look for: libcairo-*.dll, libpng*.dll, zlib*.dll
      * HB_WITH_CUPS - libcups (printing) [*nix, free, open-source]
-        * <http://www.cups.org/>
+        * <https://www.cups.org/>
      * HB_WITH_CURL - libcurl (file transfer) [multiplatform, free, open-source]
-        * <http://curl.haxx.se/>
+        * <https://curl.haxx.se/>
      * HB_WITH_EXPAT - Expat (XML parser) [multiplatform, free, open-source]
         * <http://expat.sourceforge.net/>
      * HB_WITH_FIREBIRD - firebird SQL [multiplatform, free, open-source]
-        * <http://www.firebirdsql.org/>
+        * <https://www.firebirdsql.org/>
      * HB_WITH_FREEIMAGE - FreeImage [multiplatform, free, open-source]
         * <http://freeimage.sourceforge.net/>
      * HB_WITH_GD - GD Graphics Library [multiplatform, free, open-source]
         * <http://www.libgd.org/>
      * HB_WITH_GS - Ghostscript [multiplatform, free, open-source]
-        * <http://www.ghostscript.com/>
+        * <https://www.ghostscript.com/>
         * <http://pages.cs.wisc.edu/~ghost/>
      * HB_WITH_JPEG - jpeglib [multiplatform, free, open-source]
-        * <http://www.ijg.org/>
+        * <https://www.ijg.org/>
      * HB_WITH_LIBHARU - libharu (PDF creation) [multiplatform, free, open-source]
         * <http://libharu.org/>
      * HB_WITH_LIBMAGIC - libmagic, file recognition [multiplatform, free, open-source]
@@ -1805,39 +1806,39 @@ Supported shells per host platforms:
      * HB_WITH_LZF - lzf library (RT data compression) [multiplatform, free, open-source]
         * <http://liblzf.plan9.de/>
      * HB_WITH_MINILZO - miniLZO library (RT data compression) [multiplatform, free, open-source]
-        * <http://www.oberhumer.com/opensource/lzo/>
+        * <https://www.oberhumer.com/opensource/lzo/>
      * HB_WITH_MINIZIP - minizip library [multiplatform, free, open-source]
-        * <http://www.winimage.com/zLibDll/minizip.html>
+        * <https://www.winimage.com/zLibDll/minizip.html>
      * HB_WITH_MXML - miniXML library (small XML library) [multiplatform, free, open-source]
-        * <http://www.minixml.org>
+        * <https://www.msweet.org/mxml/>
      * HB_WITH_MYSQL - MySQL [multiplatform, free, open-source]
-        * <http://dev.mysql.com/downloads/>
+        * <https://dev.mysql.com/downloads/>
      * HB_WITH_OCILIB - OCILIB (C Driver for Oracle) [multiplatform, free, open-source]
-        * <http://orclib.sourceforge.net/>
-        * <http://www.oracle.com/technology/tech/oci/instantclient/index.html>
+        * <https://vrogier.github.io/ocilib/>
+        * <https://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html>
      * HB_WITH_OPENSSL - OpenSSL [multiplatform, free, open-source]
-        * <http://www.openssl.org/>
-        * <http://www.openssl.org/related/binaries.html>
-        * <http://wiki.opensslfoundation.com/>
+        * <https://www.openssl.org/>
+        * <https://wiki.openssl.org/index.php/Binaries>
+        * <https://wiki.openssl.org/index.php/Main_Page>
      * HB_WITH_PCRE - Perl Compatible Regular Expressions [multiplatform, free, open-source]
-        * <http://www.pcre.org/>
+        * <https://www.pcre.org/>
      * HB_WITH_PGSQL - PostgreSQL [multiplatform, free, open-source]
-        * <http://www.postgresql.org/>
+        * <https://www.postgresql.org/>
      * HB_WITH_PNG - libpng [multiplatform, free, open-source]
         * <http://www.libpng.org/pub/png/libpng.html>
      * HB_WITH_QT - QT (GUI) [multiplatform, free, open-source]
         * <https://qt-project.org/>
-        * <http://download.qt-project.org/official_releases/qt/>
+        * <https://download.qt-project.org/official_releases/qt/>
      * HB_WITH_SQLITE3 - sqlite3 [multiplatform, free, open-source]
-        * <http://www.sqlite.org/>
+        * <https://www.sqlite.org/>
      * HB_WITH_TIFF - libtiff [multiplatform, free, open-source]
         * <http://www.libtiff.org/>
      * HB_WITH_TINYMT - TinyMT (Mersenne Twister) [multiplatform, free, open-source]
         * <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/TINYMT/>
      * HB_WITH_WATT - Watt-32 (TCP/IP sockets) [dos, free, open-source]
-        * <http://home.broadpark.no/~gvanem/>
+        * <http://www.watt-32.net/>
      * HB_WITH_ZLIB - zlib [multiplatform, free, open-source]
-        * <http://www.zlib.net/>
+        * <https://www.zlib.net/>
      * HB_WITH_XDIFF - libxdiff (file differences/patches) [multiplatform, free, open-source]
         * <http://www.xmailserver.org/xdiff-lib.html>
 
@@ -1846,7 +1847,7 @@ Supported shells per host platforms:
         * Search for `w95ws2setup.exe`
             (required for Win95 support to run applications built with Harbour)
      * Windows UNICOWS .dll [win, free, closed-source]
-        * <http://go.microsoft.com/fwlink/?LinkId=14851>
+        * <https://go.microsoft.com/fwlink/?LinkId=14851>
             (required for Win9x/ME support to run applications built with Harbour in UNICODE mode)
      * Windows UNICOWS runtime/import library [win, free, open-source]
         * <http://libunicows.sourceforge.net/>

--- a/contrib/hbdoc/hbdoc.prg
+++ b/contrib/hbdoc/hbdoc.prg
@@ -768,7 +768,7 @@ STATIC PROCEDURE ShowHelp( cExtraMessage, aArgs )
       aHelp := { ;
          cExtraMessage, ;
          "Harbour Document Compiler (hbdoc) " + HBRawVersion(), ;
-         "Copyright (c) 1999-2018, " + hb_Version( HB_VERSION_URL_BASE ), ;
+         "Copyright (c) 1999-2019, " + hb_Version( HB_VERSION_URL_BASE ), ;
          "", ;
          "Syntax:", ;
          "", ;

--- a/contrib/hbformat/utils/hbformat.prg
+++ b/contrib/hbformat/utils/hbformat.prg
@@ -158,7 +158,7 @@ STATIC PROCEDURE About()
    OutStd( ;
       "Harbour Source Formatter " + HBRawVersion() + hb_eol() + ;
       "Copyright (c) 2010-" + ;
-         "2018" + ", " + ;
+         "2019" + ", " + ;
          hb_Version( HB_VERSION_URL_BASE ) + hb_eol() + ;
       "Copyright (c) 2009, Alexander S.Kresin" + hb_eol() + ;
       hb_eol() )

--- a/contrib/hbnetio/utils/hbnetio/hbnetio.prg
+++ b/contrib/hbnetio/utils/hbnetio/hbnetio.prg
@@ -836,7 +836,7 @@ STATIC PROCEDURE HB_Logo()
    OutStd( ;
       "Harbour NETIO Server " + StrTran( Version(), "Harbour " ) + hb_eol() + ;
       "Copyright (c) 2009-" + ;
-         "2018" + ", " + ;
+         "2019" + ", " + ;
          "Przemyslaw Czerpak, Viktor Szakats" + hb_eol() + ;
       hb_Version( HB_VERSION_URL_BASE ) + hb_eol() + ;
       hb_eol() )

--- a/package/harbour.mft
+++ b/package/harbour.mft
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Copyright © 1999-2018 (see application banner) -->
+<!-- Copyright © 1999-2019 (see application banner) -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
     version="3.2.0.0"

--- a/package/harbour.rc
+++ b/package/harbour.rc
@@ -11,7 +11,7 @@
 #define HB_VER_FILEVERSION_STR         HB_VER_PRODUCTVERSION_STR
 
 #define HB_NAME                        "Harbour\0"
-#define HB_COPYRIGHT                   "Copyright \xA9 1999-2018 (see application banner)\0"
+#define HB_COPYRIGHT                   "Copyright \xA9 1999-2019 (see application banner)\0"
 
 /* Version info */
 

--- a/src/compiler/hbusage.c
+++ b/src/compiler/hbusage.c
@@ -261,7 +261,7 @@ void hb_compPrintLogo( HB_COMP_DECL )
 {
    char * szVer = hb_verHarbour();
 
-   #define HB_VER_COMMIT_YEAR  "2018"
+   #define HB_VER_COMMIT_YEAR  "2019"
    #define HB_VER_ORIGIN_URL   "https://harbour.github.io/"
 
    hb_compOutStd( HB_COMP_PARAM, szVer );

--- a/src/rtl/arc4.c
+++ b/src/rtl/arc4.c
@@ -50,7 +50,14 @@
 /* XXX: Check and possibly extend this to other Unix-like platforms */
 #if ( defined( HB_OS_BSD ) && ! defined( HB_OS_DARWIN ) ) || \
    ( defined( HB_OS_LINUX ) && ! defined ( HB_OS_ANDROID ) && ! defined ( __WATCOMC__ ) )
-#  define HAVE_SYS_SYSCTL_H
+   /*
+    * sysctl() on Linux has fallen into depreciation. Newer generations
+    * of runtime C libraries, like musl, doesn't even expose it. Here we
+    * look for it only with "classic" line of libc's.
+    */
+#  if ( ! defined( HB_OS_LINUX ) || ( defined( __GLIBC__ ) || defined( __UCLIBC__ ) ) )
+#     define HAVE_SYS_SYSCTL_H
+#  endif
 #  define HAVE_DECL_CTL_KERN
 #  define HAVE_DECL_KERN_RANDOM
 #  if defined( HB_OS_LINUX )

--- a/utils/hbi18n/hbi18n.prg
+++ b/utils/hbi18n/hbi18n.prg
@@ -168,7 +168,7 @@ STATIC PROCEDURE Logo()
    OutStd( ;
       "Harbour i18n .pot/.hbl file manager " + HBRawVersion() + hb_eol() + ;
       "Copyright (c) 2009-" + ;
-         "2018" + ", " + ;
+         "2019" + ", " + ;
          "Przemyslaw Czerpak" + hb_eol() + ;
       hb_Version( HB_VERSION_URL_BASE ) + hb_eol() + ;
       hb_eol() )

--- a/utils/hbtest/hbtest.prg
+++ b/utils/hbtest/hbtest.prg
@@ -95,7 +95,7 @@ STATIC s_lDBFAvail := .F.
    ANNOUNCE HB_GTSYS
    REQUEST HB_GT_CGI_DEFAULT
 
-   #define COPYRIGHT_YEAR  "2018"
+   #define COPYRIGHT_YEAR  "2019"
 #else
    #define COPYRIGHT_YEAR  "present"
 


### PR DESCRIPTION
  * README.md
    * verified links to referenced libraries, go https where applicable.
      Thanks to Pawel Wojciechowski for the location of ADS client
library.

  * src/rtl/arc4.c
    ! fix builds on Alpine Linux and possibly others using musl libc,
      which in turn doesn't expose deprecated sysctl() anymore.

  * contrib/hbdoc/hbdoc.prg
  * contrib/hbformat/utils/hbformat.prg
  * contrib/hbnetio/utils/hbnetio/hbnetio.prg
  * package/harbour.mft
  * package/harbour.rc
  * src/compiler/hbusage.c
  * utils/hbi18n/hbi18n.prg
  * utils/hbtest/hbtest.prg
    * bumped copyright year to 2019