### PR TITLE
2019-03-19 18:12 UTC+0200 Mindaugas Kavaliauskas (dbtopas/at/dbtopas.lt)

### DIFF
--- a/config/win/global.mk
+++ b/config/win/global.mk
@@ -22,4 +22,4 @@ ifneq ($(wildcard $(TOP)$(ROOT)lib/3rd/$(HB_PLATFORM)/$(HB_COMPILER)),)
    3RDLIBS := unicows
 endif
 
-SYSLIBS += kernel32 user32 ws2_32 iphlpapi advapi32 gdi32 winmm
+SYSLIBS += winmm kernel32 user32 ws2_32 iphlpapi advapi32 gdi32

--- a/contrib/hbexpat/3rd/expat/siphash.h
+++ b/contrib/hbexpat/3rd/expat/siphash.h
@@ -87,7 +87,7 @@
 
 #include <stddef.h> /* size_t */
 
-#if defined(_WIN32) && defined(_MSC_VER) && (_MSC_VER < 1600)
+#if defined(_WIN32) && ( ( defined(_MSC_VER) && (_MSC_VER < 1600) ) || ( defined( __BORLANDC__ ) && ( __BORLANDC__ <= 0x0560 ) ) )
   /* For vs2003/7.1 up to vs2008/9.0; _MSC_VER 1600 is vs2010/10.0 */
   typedef unsigned __int8   uint8_t;
   typedef unsigned __int32 uint32_t;

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -1968,8 +1968,8 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
       cBinExt := ".exe"
       cOptPrefix := "-/"
       /* NOTE: Some targets (watcom, pocc/xcc) need kernel32 explicitly. */
-      l_aLIBSYSCORE := { "kernel32", "user32", "gdi32", "advapi32", "ws2_32", "iphlpapi" }
-      l_aLIBSYSMISC := { "winspool", "comctl32", "comdlg32", "shell32", "uuid", "ole32", "oleaut32", "mpr", "winmm", "mapi32", "imm32", "msimg32", "wininet" }
+      l_aLIBSYSCORE := { "winmm", "kernel32", "user32", "gdi32", "advapi32", "ws2_32", "iphlpapi" }
+      l_aLIBSYSMISC := { "winspool", "comctl32", "comdlg32", "shell32", "uuid", "ole32", "oleaut32", "mpr", "mapi32", "imm32", "msimg32", "wininet" }
    CASE hbmk[ _HBMK_cPLAT ] == "wce"
 #if ! defined( __PLATFORM__UNIX )
       aCOMPDET := { ;
@@ -9110,7 +9110,7 @@ STATIC PROCEDURE dep_try_detection( hbmk, dep )
 
    IF ! dep[ _HBMKDEP_lDetected ]
       dep_postprocess_one( hbmk, dep )
-      IF ! dep_try_pkg_detection( hbmk, dep )
+      IF dep[ _HBMKDEP_cControl ] == "local" .OR. ! dep_try_pkg_detection( hbmk, dep )
          dep_try_header_detection( hbmk, dep )
       ENDIF
       dep[ _HBMKDEP_lDetected ] := .T.


### PR DESCRIPTION
  * config/win/global.mk
  * utils/hbmk2/hbmk2.prg
    ! moved winmm library before kernel32. This fixes Harbour compile and
      application run on Win7 and previous Windows versions if latest MinGW
      is used.
    ; Win8+ exports timeGetTime() from both kernel32.dll and winmm.dll.
      Previous windows version exports this function only from winmm.dll.
      See discussion at https://github.com/msys2/MINGW-packages/issues/4984

  * utils/hbmk2/hbmk2.prg
    ! Fixed dependency detection. Setting HB_WITH_<package>=local was ignored
      if packages were detected using pkg-config

  * contrib/hbexpat/3rd/expat/siphash.h
    ! fixed compile error for BCC <= 5.6
    * rediffed