### PR TITLE
2020-03-24 23:34 UTC+0100 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/config/linux/clang.mk
+++ b/config/linux/clang.mk
@@ -59,6 +59,6 @@ DFLAGS += -shared $(LIBPATHS)
 DY_OUT := -o$(subst x,x, )
 DLIBS := $(foreach lib,$(HB_USER_LIBS) $(SYSLIBS),-l$(lib))
 
-DY_RULE = $(DY) $(DFLAGS) -Wl,-soname,$(DYN_NAME_CPT) $(HB_USER_DFLAGS) $(DY_OUT)$(DYN_DIR)/$@ $^ $(DLIBS) $(DYSTRIP) && $(LN) $(@F) $(DYN_FILE_NVR) && $(LN) $(@F) $(DYN_FILE_CPT)
+DY_RULE = $(DY) $(DFLAGS) -Wl,-soname,$(DYN_NAME_CPT) $(HB_USER_DFLAGS) $(DY_OUT)$(DYN_DIR)/$@ $^ $(DLIBS) $(DYSTRIP) && ([ "$(@F)" = "$(notdir $(DYN_FILE_NVR))" ] || $(LN) $(@F) $(DYN_FILE_NVR)) && ([ "$(@F)" = "$(notdir $(DYN_FILE_CPT))" ] || $(LN) $(@F) $(DYN_FILE_CPT))
 
 include $(TOP)$(ROOT)config/rules.mk

--- a/contrib/3rd/sqlite3/sqlite3.diff
+++ b/contrib/3rd/sqlite3/sqlite3.diff
@@ -1,6 +1,6 @@
-diff -urN sqlite3.orig/sqlite3.c sqlite3/sqlite3.c
---- sqlite3.orig/sqlite3.c	2014-02-02 19:05:51.208012486 +0100
-+++ sqlite3/sqlite3.c	2014-02-02 19:05:51.216012487 +0100
+diff --strip-trailing-cr -urN sqlite3.orig/sqlite3.c sqlite3/sqlite3.c
+--- sqlite3.orig/sqlite3.c	2013-12-06 15:05:16.000000000 +0000
++++ sqlite3/sqlite3.c	2019-04-22 18:53:05.000000000 +0000
 @@ -27008,7 +27008,11 @@
        ** is the same technique used by glibc to implement posix_fallocate()
        ** on systems that do not have a real fallocate() system call.
@@ -34,3 +34,13 @@ diff -urN sqlite3.orig/sqlite3.c sqlite3/sqlite3.c
    uTm.dwLowDateTime = (DWORD)(t64 & 0xFFFFFFFF);
    uTm.dwHighDateTime= (DWORD)(t64 >> 32);
    osFileTimeToLocalFileTime(&uTm,&lTm);
+@@ -73680,7 +73689,8 @@
+ 
+     /* Copy as much data as is available in the buffer into the start of
+     ** p->aAlloc[].  */
+-    memcpy(p->aAlloc, &p->aBuffer[iBuf], nAvail);
++    if( nAvail > 0 )
++      memcpy(p->aAlloc, &p->aBuffer[iBuf], nAvail);
+     p->iReadOff += nAvail;
+     nRem = nByte - nAvail;
+ 

--- a/contrib/gtwvg/gtwvgd.c
+++ b/contrib/gtwvg/gtwvgd.c
@@ -2013,8 +2013,8 @@ static LRESULT CALLBACK hb_gt_wvt_WndProc( HWND hWnd, UINT message, WPARAM wPara
                   hb_itemPutNInt( pEvParams, ( HB_MAXINT ) ( HB_PTRUINT ) hWnd );
                   hb_gt_wvt_FireEvent( pWVT, HB_GTE_PAINT, pEvParams );
                }
-               return 0;
             }
+            return 0;
          case WM_HSCROLL:
          {
             PHB_ITEM pEvParams = hb_itemNew( NULL );
@@ -2115,6 +2115,7 @@ static LRESULT CALLBACK hb_gt_wvt_WndProc( HWND hWnd, UINT message, WPARAM wPara
 
          case WM_LBUTTONUP:
             SetFocus( hWnd );
+            /* fallthrough */
          case WM_RBUTTONDOWN:
          case WM_LBUTTONDOWN:
          case WM_MBUTTONDOWN:

--- a/contrib/gtwvg/wvgwing.c
+++ b/contrib/gtwvg/wvgwing.c
@@ -477,6 +477,7 @@ HB_FUNC( WVG_STATUSBARCREATEPANEL )
             hb_retl( HB_TRUE );
             return;
          }
+         break;
       }
       case -1:
       {

--- a/contrib/hbct/dattime3.c
+++ b/contrib/hbct/dattime3.c
@@ -49,6 +49,9 @@
 #ifndef _SVID_SOURCE
 #define _SVID_SOURCE
 #endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
 
 #include "hbapi.h"
 #include "hbdate.h"

--- a/contrib/hblzf/3rd/liblzf/liblzf.diff
+++ b/contrib/hblzf/3rd/liblzf/liblzf.diff
@@ -1,6 +1,6 @@
-diff -urN liblzf.orig/lzf_c.c liblzf/lzf_c.c
---- liblzf.orig/lzf_c.c	2011-06-12 13:27:46.566657457 +0200
-+++ liblzf/lzf_c.c	2011-06-12 13:27:46.566657457 +0200
+diff --strip-trailing-cr -urN liblzf.orig/lzf_c.c liblzf/lzf_c.c
+--- liblzf.orig/lzf_c.c	2010-06-01 09:11:20.000000000 +0000
++++ liblzf/lzf_c.c	2017-02-02 15:09:36.000000000 +0000
 @@ -120,7 +120,7 @@
     * special workaround for it.
     */
@@ -10,9 +10,9 @@ diff -urN liblzf.orig/lzf_c.c liblzf/lzf_c.c
  #else
    unsigned long off;
  #endif
-diff -urN liblzf.orig/lzf.h liblzf/lzf.h
---- liblzf.orig/lzf.h	2011-06-12 13:27:46.564657718 +0200
-+++ liblzf/lzf.h	2011-06-12 13:27:46.564657718 +0200
+diff --strip-trailing-cr -urN liblzf.orig/lzf.h liblzf/lzf.h
+--- liblzf.orig/lzf.h	2008-08-25 01:40:29.000000000 +0000
++++ liblzf/lzf.h	2017-02-02 15:09:36.000000000 +0000
 @@ -37,6 +37,10 @@
  #ifndef LZF_H
  #define LZF_H
@@ -34,15 +34,45 @@ diff -urN liblzf.orig/lzf.h liblzf/lzf.h
 +
  #endif
  
-diff -urN liblzf.orig/lzfP.h liblzf/lzfP.h
---- liblzf.orig/lzfP.h	2011-06-12 13:27:46.568657801 +0200
-+++ liblzf/lzfP.h	2011-06-12 13:27:46.568657801 +0200
-@@ -141,7 +141,7 @@
+diff --strip-trailing-cr -urN liblzf.orig/lzfP.h liblzf/lzfP.h
+--- liblzf.orig/lzfP.h	2010-06-01 08:16:09.000000000 +0000
++++ liblzf/lzfP.h	2019-05-23 06:43:27.000000000 +0000
+@@ -79,7 +79,11 @@
+  * Unconditionally aligning does not cost very much, so do it if unsure
+  */
+ #ifndef STRICT_ALIGN
+-# define STRICT_ALIGN !(defined(__i386) || defined (__amd64))
++# if defined(__i386) || defined (__amd64)
++#  define STRICT_ALIGN 0
++# else
++#  define STRICT_ALIGN 1
++# endif
+ #endif
+ 
+ /*
+@@ -141,15 +145,22 @@
  #endif
  
  #ifndef LZF_USE_OFFSETS
 -# if defined (WIN32)
+-#  define LZF_USE_OFFSETS defined(_M_X64)
 +# if defined (WIN32) || defined(_WIN32)
- #  define LZF_USE_OFFSETS defined(_M_X64)
++#  if defined(_M_X64)
++#   define LZF_USE_OFFSETS 1
++#  endif
  # else
  #  if __cplusplus > 199711L
+ #   include <cstdint>
+ #  else
+ #   include <stdint.h>
+ #  endif
+-#  define LZF_USE_OFFSETS (UINTPTR_MAX > 0xffffffffU)
++#  if (UINTPTR_MAX > 0xffffffffU)
++#   define LZF_USE_OFFSETS 1
++#  endif
++# endif
++# ifndef LZF_USE_OFFSETS
++#   define LZF_USE_OFFSETS 0
+ # endif
+ #endif
+ 

--- a/contrib/hblzf/3rd/liblzf/lzfP.h
+++ b/contrib/hblzf/3rd/liblzf/lzfP.h
@@ -79,7 +79,11 @@
  * Unconditionally aligning does not cost very much, so do it if unsure
  */
 #ifndef STRICT_ALIGN
-# define STRICT_ALIGN !(defined(__i386) || defined (__amd64))
+# if defined(__i386) || defined (__amd64)
+#  define STRICT_ALIGN 0
+# else
+#  define STRICT_ALIGN 1
+# endif
 #endif
 
 /*
@@ -142,14 +146,21 @@ using namespace std;
 
 #ifndef LZF_USE_OFFSETS
 # if defined (WIN32) || defined(_WIN32)
-#  define LZF_USE_OFFSETS defined(_M_X64)
+#  if defined(_M_X64)
+#   define LZF_USE_OFFSETS 1
+#  endif
 # else
 #  if __cplusplus > 199711L
 #   include <cstdint>
 #  else
 #   include <stdint.h>
 #  endif
-#  define LZF_USE_OFFSETS (UINTPTR_MAX > 0xffffffffU)
+#  if (UINTPTR_MAX > 0xffffffffU)
+#   define LZF_USE_OFFSETS 1
+#  endif
+# endif
+# ifndef LZF_USE_OFFSETS
+#   define LZF_USE_OFFSETS 0
 # endif
 #endif
 

--- a/contrib/hbmisc/hbeditc.c
+++ b/contrib/hbmisc/hbeditc.c
@@ -123,13 +123,10 @@ static HB_ISIZ Prev( PHB_EDITOR pEd, HB_ISIZ adres )
    {
       HB_ISIZ i;
 
-      for( i = adres; i >= 0; i-- )
+      for( i = adres - 3; i >= 0; i-- )
       {
          if( pEd->begin[ i ] == '\n' )
-         {
-            if( i < adres - 2 )
-               return i + 1;
-         }
+            return i + 1;
       }
       return 0;
    }

--- a/contrib/hbodbc/hbodbc.hbp
+++ b/contrib/hbodbc/hbodbc.hbp
@@ -14,6 +14,7 @@
 -depcontrol=odbc:force{allwin&!msvcarm}
 -depincpath=odbc:/usr/include
 -depincpath=odbc:/usr/local/include
+-depincpath=odbc:/usr/include/iodbc
 
 ${hb_name}.hbx
 

--- a/contrib/hbssl/bio.c
+++ b/contrib/hbssl/bio.c
@@ -762,7 +762,7 @@ HB_FUNC( BIO_GET_CONN_INT_PORT )
     OPENSSL_VERSION_NUMBER == 0x1000112fL /* 1.0.1r */
       /* Fix for header regression */
       hb_retnl( BIO_ctrl( bio, BIO_C_GET_CONNECT, 3, NULL ) );
-#elif OPENSSL_VERSION_NUMBER >= 0x10101000L
+#elif OPENSSL_VERSION_NUMBER >= 0x1010007fL
       const BIO_ADDR * ba = BIO_get_conn_address( bio );
       hb_retnl( ba ? hb_socketNToHS( BIO_ADDR_rawport( ba ) ) : 0 );
 #else

--- a/contrib/hbwin/hbolesrv.c
+++ b/contrib/hbwin/hbolesrv.c
@@ -93,7 +93,7 @@ static DISPID hb_dynsymToDispId( PHB_DYNS pDynSym )
 static PHB_DYNS hb_dispIdToDynsym( DISPID dispid )
 {
    if( ( LONG ) dispid > 0 )
-      return hb_dynsymFromNum( ( int ) dispid );
+      return hb_dynsymFromNum( ( HB_SYMCNT ) dispid );
    else
       return NULL;
 }

--- a/contrib/sddodbc/sddodbc.hbp
+++ b/contrib/sddodbc/sddodbc.hbp
@@ -16,6 +16,7 @@ rddsql.hbc
 -depcontrol=odbc:force{allwin&!msvcarm}
 -depincpath=odbc:/usr/include
 -depincpath=odbc:/usr/local/include
+-depincpath=odbc:/usr/include/iodbc
 
 ${hb_name}.hbx
 

--- a/include/hbapi.h
+++ b/include/hbapi.h
@@ -1040,8 +1040,8 @@ extern HB_EXPORT HB_BOOL   hb_dynsymIsFunction( PHB_DYNS pDynSym );
 extern HB_EXPORT HB_BOOL   hb_dynsymIsMemvar( PHB_DYNS pDynSym );
 extern HB_EXPORT int       hb_dynsymAreaHandle( PHB_DYNS pDynSym ); /* return work area number bound with given dynamic symbol */
 extern HB_EXPORT void      hb_dynsymSetAreaHandle( PHB_DYNS pDynSym, int iArea ); /* set work area number for a given dynamic symbol */
-extern HB_EXPORT int       hb_dynsymToNum( PHB_DYNS pDynSym );
-extern HB_EXPORT PHB_DYNS  hb_dynsymFromNum( int iSymNum );
+extern HB_EXPORT HB_SYMCNT hb_dynsymToNum( PHB_DYNS pDynSym );
+extern HB_EXPORT PHB_DYNS  hb_dynsymFromNum( HB_SYMCNT iSymNum );
 #ifdef _HB_API_INTERNAL_
 extern           PHB_ITEM  hb_dynsymGetMemvar( PHB_DYNS pDynSym ); /* return memvar handle number bound with given dynamic symbol */
 extern           void      hb_dynsymSetMemvar( PHB_DYNS pDynSym, PHB_ITEM pMemvar ); /* set memvar handle for a given dynamic symbol */

--- a/include/hbdefs.h
+++ b/include/hbdefs.h
@@ -466,6 +466,8 @@ typedef HB_UCHAR            HB_U8;
 typedef HB_MAXINT    HB_VMMAXINT;
 typedef HB_MAXUINT   HB_VMMAXUINT;
 
+typedef HB_U32       HB_SYMCNT;
+
 #define HB_DBL_LIM_INT(d)     ( HB_VMINT_MIN <= (d) && (d) <= HB_VMINT_MAX )
 #define HB_DBL_LIM_LONG(d)    ( (HB_MAXDBL) HB_VMLONG_MIN <= (HB_MAXDBL) (d) && (HB_MAXDBL) (d) <= (HB_MAXDBL) HB_VMLONG_MAX )
 #define HB_LIM_INT(l)         ( HB_VMINT_MIN <= (l) && (l) <= HB_VMINT_MAX )
@@ -669,19 +671,22 @@ typedef HB_U32 HB_FATTR;
 
 #     define HB_BIG_ENDIAN
 
-#  elif ( defined( __BYTE_ORDER ) && defined( __LITTLE_ENDIAN ) && __BYTE_ORDER == __LITTLE_ENDIAN ) || \
+#  elif ( defined( __BYTE_ORDER__ ) && defined( __LITTLE_ENDIAN__ ) && __BYTE_ORDER__ == __LITTLE_ENDIAN__ ) || \
+        ( defined( __BYTE_ORDER ) && defined( __LITTLE_ENDIAN ) && __BYTE_ORDER == __LITTLE_ENDIAN ) || \
         ( defined( _BYTE_ORDER ) && defined( _LITTLE_ENDIAN ) && _BYTE_ORDER == _LITTLE_ENDIAN ) || \
         ( defined( BYTE_ORDER ) && defined( LITTLE_ENDIAN ) && BYTE_ORDER == LITTLE_ENDIAN )
 
 #     define HB_LITTLE_ENDIAN
 
-#  elif ( defined( __BYTE_ORDER ) && defined( __BIG_ENDIAN ) && __BYTE_ORDER == __BIG_ENDIAN ) || \
+#  elif ( defined( __BYTE_ORDER__ ) && defined( __BIG_ENDIAN__ ) && __BYTE_ORDER__ == __BIG_ENDIAN__ ) || \
+        ( defined( __BYTE_ORDER ) && defined( __BIG_ENDIAN ) && __BYTE_ORDER == __BIG_ENDIAN ) || \
         ( defined( _BYTE_ORDER ) && defined( _BIG_ENDIAN ) && _BYTE_ORDER == _BIG_ENDIAN ) || \
         ( defined( BYTE_ORDER ) && defined( BIG_ENDIAN ) && BYTE_ORDER == BIG_ENDIAN )
 
 #     define HB_BIG_ENDIAN
 
-#  elif ( defined( __BYTE_ORDER ) && defined( __PDP_ENDIAN ) && __BYTE_ORDER == __PDP_ENDIAN ) || \
+#  elif ( defined( __BYTE_ORDER__ ) && defined( __PDP_ENDIAN__ ) && __BYTE_ORDER__ == __PDP_ENDIAN__ ) || \
+        ( defined( __BYTE_ORDER ) && defined( __PDP_ENDIAN ) && __BYTE_ORDER == __PDP_ENDIAN ) || \
         ( defined( _BYTE_ORDER ) && defined( _PDP_ENDIAN ) && _BYTE_ORDER == _PDP_ENDIAN ) || \
         ( defined( BYTE_ORDER ) && defined( PDP_ENDIAN ) && BYTE_ORDER == PDP_ENDIAN )
 

--- a/include/hbstack.h
+++ b/include/hbstack.h
@@ -173,7 +173,7 @@ typedef struct
 #if defined( HB_MT_VM )
    int        iUnlocked;      /* counter for nested hb_vmUnlock() calls */
    PHB_DYN_HANDLES pDynH;     /* dynamic symbol handles */
-   int        iDynH;          /* number of dynamic symbol handles */
+   HB_SYMCNT  uiDynH;         /* number of dynamic symbol handles */
    void *     pStackLst;      /* this stack entry in stack linked list */
    HB_IOERRORS IOErrors;      /* MT safe buffer for IO errors */
    HB_TRACEINFO traceInfo;    /* MT safe buffer for HB_TRACE data */
@@ -359,8 +359,8 @@ extern void        hb_stackUpdateAllocator( void *, PHB_ALLOCUPDT_FUNC, int );
    extern void             hb_stackListSet( void * pStackLst );
    extern void             hb_stackIdSetActionRequest( void * pStackID, HB_USHORT uiAction );
    extern PHB_DYN_HANDLES  hb_stackGetDynHandle( PHB_DYNS pDynSym );
-   extern int              hb_stackDynHandlesCount( void );
-   extern void             hb_stackClearMemvars( int );
+   extern HB_SYMCNT        hb_stackDynHandlesCount( void );
+   extern void             hb_stackClearMemvars( HB_SYMCNT );
    extern HB_BOOL          hb_stackQuitState( void );
    extern void             hb_stackSetQuitState( HB_USHORT uiState );
    extern int              hb_stackUnlock( void );
@@ -409,7 +409,7 @@ extern void        hb_stackUpdateAllocator( void *, PHB_ALLOCUPDT_FUNC, int );
 #if defined( HB_MT_VM )
 #  define hb_stackList()            ( hb_stack.pStackLst )
 #  define hb_stackListSet( p )      do { hb_stack.pStackLst = ( p ); } while( 0 )
-#  define hb_stackDynHandlesCount() ( hb_stack.iDynH )
+#  define hb_stackDynHandlesCount() ( hb_stack.uiDynH )
 #  define hb_stackQuitState( )      ( hb_stack.uiQuitState != 0 )
 #  define hb_stackSetQuitState( n ) do { hb_stack.uiQuitState = ( n ); } while( 0 )
 #  define hb_stackUnlock()          ( ++hb_stack.iUnlocked )

--- a/include/hbvmpub.h
+++ b/include/hbvmpub.h
@@ -135,7 +135,7 @@ struct _HB_SYMB;
       void *    pMemvar;          /* memvar pointer ( publics & privates ) */
       HB_USHORT uiArea;           /* Workarea number */
 #  endif /* ! HB_MT_VM */
-      HB_USHORT uiSymNum;         /* dynamic symbol number */
+      HB_SYMCNT uiSymNum;         /* dynamic symbol number */
 #  if ! defined( HB_NO_PROFILER )
       HB_ULONG  ulCalls;          /* profiler support */
       HB_ULONG  ulTime;           /* profiler support */

--- a/src/3rd/png/Makefile
+++ b/src/3rd/png/Makefile
@@ -48,6 +48,7 @@ ifeq ($(filter $(HB_COMPILER),poccarm xcc tcc),)
          ifneq ($(filter $(HB_COMPILER),pocc pocc64 poccarm),)
             HB_CFLAGS += -DPNG_ALLOCATED
          endif
+         HB_CFLAGS += -DPNG_ARM_NEON_OPT=0
 
          include $(TOP)$(ROOT)config/lib.mk
       else

--- a/src/vm/dynsym.c
+++ b/src/vm/dynsym.c
@@ -84,18 +84,18 @@ HB_SYM_HOLDER, * PHB_SYM_HOLDER;
 
 
 static PDYNHB_ITEM s_pDynItems = NULL;    /* Pointer to dynamic items */
-static HB_USHORT   s_uiDynSymbols = 0;    /* Number of symbols present */
+static HB_SYMCNT   s_uiDynSymbols = 0;    /* Number of symbols present */
 
 static PHB_SYM_HOLDER s_pAllocSyms = NULL;/* symbols allocated dynamically */
 
 /* table index for dynamic symbol to number conversions */
 static PDYNHB_ITEM s_pDynIndex = NULL;
-static int         s_iDynIdxSize = 0;
+static HB_SYMCNT   s_uiDynIdxSize = 0;
 
 /* Insert new symbol into dynamic symbol table.
  * In MT mode caller should protected it by HB_DYNSYM_LOCK()
  */
-static PHB_DYNS hb_dynsymInsert( PHB_SYMB pSymbol, HB_UINT uiPos )
+static PHB_DYNS hb_dynsymInsert( PHB_SYMB pSymbol, HB_SYMCNT uiPos )
 {
    PHB_DYNS pDynSym;
 
@@ -130,9 +130,9 @@ static PHB_DYNS hb_dynsymInsert( PHB_SYMB pSymbol, HB_UINT uiPos )
  * If not found set position for insert operation.
  * In MT mode caller should protected it by HB_DYNSYM_LOCK()
  */
-static PHB_DYNS hb_dynsymPos( const char * szName, HB_UINT * puiPos )
+static PHB_DYNS hb_dynsymPos( const char * szName, HB_SYMCNT * puiPos )
 {
-   HB_UINT uiFirst, uiLast, uiMiddle;
+   HB_SYMCNT uiFirst, uiLast, uiMiddle;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymPos(%s, %p)", szName, ( void * ) puiPos ) );
 
@@ -188,7 +188,7 @@ static PHB_SYMB hb_symbolAlloc( const char * szName )
 /* Find symbol in dynamic symbol table */
 PHB_DYNS hb_dynsymFind( const char * szName )
 {
-   HB_UINT uiFirst, uiLast;
+   HB_SYMCNT uiFirst, uiLast;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymFind(%s)", szName ) );
 
@@ -199,7 +199,7 @@ PHB_DYNS hb_dynsymFind( const char * szName )
 
    while( uiFirst < uiLast )
    {
-      HB_UINT uiMiddle = ( uiFirst + uiLast ) >> 1;
+      HB_SYMCNT uiMiddle = ( uiFirst + uiLast ) >> 1;
       int iCmp = strcmp( s_pDynItems[ uiMiddle ].pDynSym->pSymbol->szName, szName );
 
       if( iCmp == 0 )
@@ -238,7 +238,7 @@ PHB_SYMB hb_symbolNew( const char * szName )
 PHB_DYNS hb_dynsymNew( PHB_SYMB pSymbol )
 {
    PHB_DYNS pDynSym;
-   HB_UINT uiPos;
+   HB_SYMCNT uiPos;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymNew(%p)", ( void * ) pSymbol ) );
 
@@ -358,7 +358,7 @@ PHB_DYNS hb_dynsymNew( PHB_SYMB pSymbol )
 PHB_DYNS hb_dynsymGetCase( const char * szName )
 {
    PHB_DYNS pDynSym;
-   HB_UINT uiPos;
+   HB_SYMCNT uiPos;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymGetCase(%s)", szName ) );
 
@@ -525,43 +525,43 @@ HB_LONG hb_dynsymCount( void )
    return s_uiDynSymbols;
 }
 
-int hb_dynsymToNum( PHB_DYNS pDynSym )
+HB_SYMCNT hb_dynsymToNum( PHB_DYNS pDynSym )
 {
-   int iSymNum;
+   HB_SYMCNT uiSymNum;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymToNum(%p)", ( void * ) pDynSym ) );
 
    HB_DYNSYM_LOCK();
 
-   iSymNum = pDynSym->uiSymNum;
+   uiSymNum = pDynSym->uiSymNum;
 
-   if( iSymNum > s_iDynIdxSize )
+   if( uiSymNum > s_uiDynIdxSize )
    {
       s_pDynIndex = ( PDYNHB_ITEM )
-                    hb_xrealloc( s_pDynIndex, iSymNum * sizeof( DYNHB_ITEM ) );
-      memset( &s_pDynIndex[ s_iDynIdxSize ], 0, ( iSymNum - s_iDynIdxSize ) *
-                                                sizeof( DYNHB_ITEM ) );
-      s_iDynIdxSize = iSymNum;
+                    hb_xrealloc( s_pDynIndex, uiSymNum * sizeof( DYNHB_ITEM ) );
+      memset( &s_pDynIndex[ s_uiDynIdxSize ], 0, ( uiSymNum - s_uiDynIdxSize ) *
+                                                 sizeof( DYNHB_ITEM ) );
+      s_uiDynIdxSize = uiSymNum;
    }
 
-   if( s_pDynIndex[ iSymNum - 1 ].pDynSym == NULL )
-      s_pDynIndex[ iSymNum - 1 ].pDynSym = pDynSym;
+   if( s_pDynIndex[ uiSymNum - 1 ].pDynSym == NULL )
+      s_pDynIndex[ uiSymNum - 1 ].pDynSym = pDynSym;
 
    HB_DYNSYM_UNLOCK();
 
-   return iSymNum;
+   return uiSymNum;
 }
 
-PHB_DYNS hb_dynsymFromNum( int iSymNum )
+PHB_DYNS hb_dynsymFromNum( HB_SYMCNT uiSymNum )
 {
    PHB_DYNS pDynSym;
 
-   HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymFromNum(%d)", iSymNum ) );
+   HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymFromNum(%d)", uiSymNum ) );
 
    HB_DYNSYM_LOCK();
 
-   pDynSym = iSymNum > 0 && iSymNum <= s_iDynIdxSize ?
-             s_pDynIndex[ iSymNum - 1 ].pDynSym : NULL;
+   pDynSym = uiSymNum > 0 && uiSymNum <= s_uiDynIdxSize ?
+             s_pDynIndex[ uiSymNum - 1 ].pDynSym : NULL;
 
    HB_DYNSYM_UNLOCK();
 
@@ -571,7 +571,7 @@ PHB_DYNS hb_dynsymFromNum( int iSymNum )
 void hb_dynsymEval( PHB_DYNS_FUNC pFunction, void * Cargo )
 {
    PHB_DYNS pDynSym = NULL;
-   HB_USHORT uiPos = 0;
+   HB_SYMCNT uiPos = 0;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymEval(%p, %p)", ( void * ) pFunction, Cargo ) );
 
@@ -605,7 +605,7 @@ void hb_dynsymEval( PHB_DYNS_FUNC pFunction, void * Cargo )
 
 void hb_dynsymProtectEval( PHB_DYNS_FUNC pFunction, void * Cargo )
 {
-   HB_USHORT uiPos = 0;
+   HB_SYMCNT uiPos = 0;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymProtectEval(%p, %p)", ( void * ) pFunction, Cargo ) );
 
@@ -626,11 +626,11 @@ void hb_dynsymRelease( void )
 
    HB_DYNSYM_LOCK();
 
-   if( s_iDynIdxSize )
+   if( s_uiDynIdxSize )
    {
       hb_xfree( s_pDynIndex );
       s_pDynIndex = NULL;
-      s_iDynIdxSize = 0;
+      s_uiDynIdxSize = 0;
    }
 
    if( s_uiDynSymbols )
@@ -671,7 +671,7 @@ HB_FUNC( __DYNSGETNAME ) /* Get name of symbol: cSymbol = __dynsymGetName( dsInd
 HB_FUNC( __DYNSGETINDEX ) /* Gimme index number of symbol: dsIndex = __dynsymGetIndex( cSymbol ) */
 {
    HB_STACK_TLS_PRELOAD
-   HB_UINT uiPos = 0;
+   HB_SYMCNT uiPos = 0;
    const char * szName = hb_parc( 1 );
 
    if( szName )
@@ -772,7 +772,7 @@ HB_FUNC( __DYNSP2NAME )
 /* internal function used to debug dynamic symbol integrity */
 static int hb_dynsymVerify( void )
 {
-   HB_USHORT uiPos = 0;
+   HB_SYMCNT uiPos = 0;
    int iResult = 0;
 
    HB_TRACE( HB_TR_DEBUG, ( "hb_dynsymVerify()" ) );
@@ -782,7 +782,7 @@ static int hb_dynsymVerify( void )
    while( iResult == 0 && uiPos < s_uiDynSymbols )
    {
       PHB_DYNS pDynSym = s_pDynItems[ uiPos ].pDynSym;
-      HB_UINT uiAt;
+      HB_SYMCNT uiAt;
       int iCmp;
 
       if( uiPos > 0 &&
@@ -791,7 +791,7 @@ static int hb_dynsymVerify( void )
          iResult = iCmp == 0 ? -1 : -2;
       else if( hb_dynsymPos( pDynSym->pSymbol->szName, &uiAt ) != pDynSym )
          iResult = -3;
-      else if( uiAt != ( HB_UINT ) uiPos )
+      else if( uiAt != uiPos )
          iResult = -4;
       else
          ++uiPos;

--- a/src/vm/memvars.c
+++ b/src/vm/memvars.c
@@ -834,10 +834,10 @@ void hb_memvarsClear( HB_BOOL fAll )
 #else
    /* this is a little bit hacked but many times faster version
     * of memvars clearing because it scans only given thread stack
-    * not global dynamic symbol table. It noticeable reduce the cost
-    * of HVM thread releasing.
+    * not global dynamic symbol table. It noticeable reduces the cost
+    * of HVM thread releasing [druzus].
     */
-   hb_stackClearMemvars( pGetList ? ( int ) pGetList->uiSymNum : -1 );
+   hb_stackClearMemvars( pGetList ? pGetList->uiSymNum : 0 );
 #endif
 }
 

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -1857,7 +1857,7 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
       CASE hbmk[ _HBMK_cPLAT ] == "sunos"
          aCOMPSUP := { "gcc", "sunpro", "pcc" }
       CASE hbmk[ _HBMK_cPLAT ] == "android"
-         aCOMPSUP := { "gcc", "gccarm" }
+         aCOMPSUP := { "gcc", "gccarm", "clang" }
       CASE hbmk[ _HBMK_cPLAT ] == "vxworks"
          aCOMPSUP := { "gcc", "diab" }
       CASE hbmk[ _HBMK_cPLAT ] == "aix"
@@ -3978,6 +3978,7 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
            ( hbmk[ _HBMK_cPLAT ] == "darwin"  .AND. hbmk[ _HBMK_cCOMP ] == "clang" ) .OR. ;
            ( hbmk[ _HBMK_cPLAT ] == "bsd"     .AND. hbmk[ _HBMK_cCOMP ] == "clang" ) .OR. ;
            ( hbmk[ _HBMK_cPLAT ] == "minix"   .AND. hbmk[ _HBMK_cCOMP ] == "clang" ) .OR. ;
+           ( hbmk[ _HBMK_cPLAT ] == "android" .AND. hbmk[ _HBMK_cCOMP ] == "clang" ) .OR. ;
            ( hbmk[ _HBMK_cPLAT ] == "beos"    .AND. hbmk[ _HBMK_cCOMP ] == "gcc" ) .OR. ;
            ( hbmk[ _HBMK_cPLAT ] == "qnx"     .AND. hbmk[ _HBMK_cCOMP ] == "gcc" ) .OR. ;
            ( hbmk[ _HBMK_cPLAT ] == "android" .AND. hbmk[ _HBMK_cCOMP ] == "gcc" ) .OR. ;
@@ -4037,8 +4038,13 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
             cBin_CompC := iif( hbmk[ _HBMK_lCPP ] != NIL .AND. hbmk[ _HBMK_lCPP ], cBin_CompCPP, "icc" )
             AAdd( hbmk[ _HBMK_aOPTC ], "-D_GNU_SOURCE" )
          CASE hbmk[ _HBMK_cCOMP ] == "clang"
-            cBin_CompC := hbmk[ _HBMK_cCCPREFIX ] + "clang" + hbmk[ _HBMK_cCCSUFFIX ]
-            cBin_CompCPP := cBin_CompC
+            IF hbmk[ _HBMK_cPLAT ] == "android"
+               cBin_CompCPP := hbmk[ _HBMK_cCCPREFIX ] + "clang++" + hbmk[ _HBMK_cCCSUFFIX ]
+               cBin_CompC := iif( hbmk[ _HBMK_lCPP ] != NIL .AND. hbmk[ _HBMK_lCPP ], cBin_CompCPP, hbmk[ _HBMK_cCCPREFIX ] + "clang" + hbmk[ _HBMK_cCCSUFFIX ] )
+            ELSE
+               cBin_CompC := hbmk[ _HBMK_cCCPREFIX ] + "clang" + hbmk[ _HBMK_cCCSUFFIX ]
+               cBin_CompCPP := cBin_CompC
+            ENDIF
          CASE hbmk[ _HBMK_cCOMP ] == "pcc"
             cBin_CompC := hbmk[ _HBMK_cCCPREFIX ] + "pcc" + hbmk[ _HBMK_cCCSUFFIX ]
          CASE hbmk[ _HBMK_cCOMP ] == "open64"
@@ -15801,7 +15807,7 @@ STATIC PROCEDURE ShowHelp( hbmk, lMore, lLong )
       { "hpux"    , "gcc" }, ;
       { "beos"    , "gcc" }, ;
       { "qnx"     , "gcc" }, ;
-      { "android" , "gcc, gccarm" }, ;
+      { "android" , "gcc, gccarm, clang" }, ;
       { "vxworks" , "gcc, diab" }, ;
       { "symbian" , "gcc" }, ;
       { "cygwin"  , "gcc" }, ;


### PR DESCRIPTION
  * config/linux/clang.mk
    ! fixed rule for dynamic library

  * src/3rd/png/Makefile
    + added -DPNG_ARM_NEON_OPT=0 to build flags

  * contrib/3rd/sqlite3/sqlite3.c
  * contrib/3rd/sqlite3/sqlite3.diff
    ! pacified warning

  * contrib/gtwvg/gtwvgd.c
  * contrib/gtwvg/wvgwing.c
    ! fixed missing break/return in case statements - please verify it.

  * contrib/hbct/dattime3.c
    * added #define _DEFAULT_SOURCE necessay in new Linux distors

  * contrib/hblzf/3rd/liblzf/liblzf.diff
  * contrib/hblzf/3rd/liblzf/lzfP.h
    * do not use nested #define in #if statements - some C compilers do not
      support it

  * contrib/hbssl/bio.c
    ! tuned #if condition

  * contrib/hbmisc/hbeditc.c
    * simpliefied for condition and pacified warning

  * contrib/hbodbc/hbodbc.hbp
  * contrib/sddodbc/sddodbc.hbp
    + added check for iodbc library

  * utils/hbmk2/hbmk2.prg
    + added support for clang in android builds

  * include/hbdefs.h
    + added check for __BYTE_ORDER__ macro used in some new lib C
      implementations

  * include/hbapi.h
  * include/hbdefs.h
  * include/hbstack.h
  * include/hbvmpub.h
  * src/vm/classes.c
  * src/vm/dynsym.c
  * src/vm/estack.c
  * src/vm/memvars.c
    + extended the size of dynamic symbol table from 65535 to 4294967295.
      Adopting class code I decided to keep current algorithm of method indexes
      hashing with only some minor modifications. It's very fast anyhow it may
      cause noticeable (though static) quite big memory allocation for class
      definitions in applications using millions of symbols and which increase
      dynamic symbol table at runtime loading new classes dynamically form .hrb,
      .dll, .so or other dynamic libraries supported by Harbour. It's random
      and rather impossible to exploit situation in real life anyhow I cannot
      exclude it so I'd like to report it in ChangeLog. The solution is very
      simple, i.e. it's enough to use classic divide et impera algorithm using
      symbol numbers to find method definition anyhow it will be slower then
      current one and address only very seldom hypothetical situations so I
      decided to not implement it. Such static memory cost begins to be
      completely unimportant in the world of 64-bit architectures and extremely
      big memory address space.
      The modification was sponsored by TRES company.

  * src/vm/estack.c
    ! fixed __mvClear() in MT builds - due to stupid typo GetList variable
      was removed in MT programs by CLEAR MEMORY command (__mvClear())
      So far noone reported it and I've found it analyzing the code before
      increasing symbol table size.

  * contrib/hbwin/hbolesrv.c
    * updated for new size of dynamic symbol table