### PR TITLE
2020-06-30 18:01 UTC+0200 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/contrib/gtqtc/gtqtc.hbc
+++ b/contrib/gtqtc/gtqtc.hbc
@@ -6,6 +6,7 @@ deppkgname=qt5:qt5
 depcontrol=qt5:${HB_WITH_QT}
 depkeyhead=qt5:QtCore/QJsonObject
 depoptional=qt5:yes
+depincpath=qt5:/usr/include/x86_64-linux-gnu/qt5{linux}
 depincpath=qt5:/usr/local/opt/qt5/include{darwin}
 depincpath=qt5:/usr/local/include/qt5{bsd}
 depfinish=qt5

--- a/contrib/gtqtc/gtqtc1.cpp
+++ b/contrib/gtqtc/gtqtc1.cpp
@@ -2300,9 +2300,12 @@ static HB_BOOL hb_gt_qtc_Info( PHB_GT pGT, int iType, PHB_GT_INFO pInfo )
             /* filename or resource */
             if( HB_IS_STRING( pInfo->pNewVal ) )
             {
-               QString qStr;
-               hb_gt_qtc_itemGetQString( pInfo->pNewVal, &qStr );
-               qImg = QImage( qStr );
+               if( hb_itemGetCLen( pInfo->pNewVal ) > 0 )
+               {
+                  QString qStr;
+                  hb_gt_qtc_itemGetQString( pInfo->pNewVal, &qStr );
+                  qImg = QImage( qStr );
+               }
             }
             else if( hb_arrayLen( pInfo->pNewVal ) == static_cast< HB_SIZE >
                      ( ( hb_arrayGetType( pInfo->pNewVal, 4 ) & HB_IT_NUMERIC ) ? 4 : 3 ) &&
@@ -3067,7 +3070,12 @@ void QTConsole::wheelEvent( QWheelEvent * evt )
          break;
 
       case Qt::Horizontal:
-         /* TODO? add support for horizontal wheels */
+         if( evt->delta() < 0 )
+            iKey = K_MWLEFT;
+         else
+            iKey = K_MWRIGHT;
+         break;
+
       default:
          QWidget::wheelEvent( evt );
          return;


### PR DESCRIPTION
  * contrib/gtqtc/gtqtc.hbc
    * added default Qt5 path in Ubuntu64

  * contrib/gtqtc/gtqtc1.cpp
    + added support for horizontal wheel events
    * do not try to load image when zero length string is used as image name
      to refresh screen in HB_GTI_DISPIMAGE