### PR TITLE
2020-08-19 02:02 UTC+0200 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/src/rtl/filesys.c
+++ b/src/rtl/filesys.c
@@ -1137,7 +1137,7 @@ HB_FHANDLE hb_fsPOpen( const char * pszFileName, const char * pszMode )
                   HB_FAILURE_RETRY( iResult, execv( "/bin/sh", ( char ** ) HB_UNCONST( argv ) ) );
 #endif
                }
-               exit( pid > 0 ? 0 : 1 );
+               _exit( pid > 0 ? EXIT_SUCCESS : EXIT_FAILURE );
             }
          }
          else

--- a/src/rtl/gtchrmap.c
+++ b/src/rtl/gtchrmap.c
@@ -464,7 +464,7 @@ int main( int argc, char ** argv )
    if( hb_gt_chrmapinit( piTransTbl, NULL ) == -1 )
    {
       printf( "cannot init charmap.\n" );
-      exit( 1 );
+      return 1;
    }
 
    for( i = 0; i < 256; ++i )

--- a/src/rtl/gtcrs/gtcrs.c
+++ b/src/rtl/gtcrs/gtcrs.c
@@ -2164,7 +2164,7 @@ static InOutBase * create_newXterm( void )
       execlp( "xterm", "xterm", buf, "+sb",
               "-fg", "white",
               "-bg", "black", "-fn", "fixed", "-T", "HB-XTERM Window", NULL );
-      exit( 0 );
+      _exit( EXIT_FAILURE );
    }
    close( masterfd );
    return create_ioBase( "xterm", slavefd, slavefd, slavefd, termpid );

--- a/src/rtl/hbproces.c
+++ b/src/rtl/hbproces.c
@@ -429,7 +429,7 @@ static int hb_fsProcessExec( const char * pszFileName,
 
          /* execute command */
          execvp( argv[ 0 ], argv );
-         exit( -1 );
+         _exit( EXIT_FAILURE );
       }
       else if( pid != -1 )
       {
@@ -857,7 +857,7 @@ HB_FHANDLE hb_fsProcessOpen( const char * pszFileName,
 #  else
             execvp( argv[ 0 ], argv );
 #  endif
-            exit( -1 );
+            _exit( EXIT_FAILURE );
          }
       }
       hb_fsSetIOError( ! fError, 0 );


### PR DESCRIPTION
  * src/rtl/filesys.c
    ! use _exit() instead of exit() in forked process inside hb_fsPOpen().
      I've noticed that programs linked with QT 5.9.5 does not cleanly ends
      when exit() is used probably due to atexit() procedures.
    * use EXIT_SUCCESS and EXIT_FAILURE macros

  * src/rtl/gtcrs/gtcrs.c
  * src/rtl/hbproces.c
    * use _exit() instead of exit() in forked processes when exec*() fails
    * use EXIT_SUCCESS and EXIT_FAILURE macros

  * src/rtl/gtchrmap.c
    * use 'return 0' instead of 'exit( 0 )' in commented debug code