### PR TITLE
2023-01-16 14:35 UTC+0100 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/contrib/hbwin/wapi_shellapi.c
+++ b/contrib/hbwin/wapi_shellapi.c
@@ -85,8 +85,10 @@ HB_FUNC( WAPI_SHELLEXECUTE_WAIT )
    void * hDirectory;
    BOOL retVal;
    MSG msg;
-   SHELLEXECUTEINFO ShExecInfo = {0};
-   ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+   SHELLEXECUTEINFO ShExecInfo;
+
+   memset( &ShExecInfo, 0, sizeof( ShExecInfo ) );
+   ShExecInfo.cbSize = sizeof( SHELLEXECUTEINFO );
    ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
    ShExecInfo.hwnd = ( HWND ) hb_parptr( 1 );
    ShExecInfo.lpVerb = HB_PARSTR( 2, &hOperation, NULL );
@@ -95,9 +97,9 @@ HB_FUNC( WAPI_SHELLEXECUTE_WAIT )
    ShExecInfo.lpDirectory = HB_PARSTR( 5, &hDirectory, NULL );
    ShExecInfo.nShow = hb_parnidef( 6, SW_SHOWNORMAL );
    ShExecInfo.hInstApp = NULL;
-   retVal = ShellExecuteEx(&ShExecInfo);
+   retVal = ShellExecuteEx( &ShExecInfo );
    hb_retl( retVal );
-   while( WaitForSingleObject(ShExecInfo.hProcess,1000) != WAIT_OBJECT_0 )
+   while( WaitForSingleObject( ShExecInfo.hProcess, 1000 ) != WAIT_OBJECT_0 )
    {
       while( PeekMessage( &msg, ( HWND ) NULL, 0, 0, PM_REMOVE ) )
       {

--- a/src/pp/hbpp.c
+++ b/src/pp/hbpp.c
@@ -350,7 +350,7 @@ static int hb_pp_generateVerInfo( char * szVerFile,
                " * and is covered by the same license as Harbour PP\n"
                " */\n\n" );
 
-      fprintf( fout, "#define HB_VER_REVID             %" PFHL "u" PFHL "u\n", nRevID );
+      fprintf( fout, "#define HB_VER_REVID             %" PFHL "ulu\n", nRevID );
 
       if( szChangeLogID )
       {


### PR DESCRIPTION
  * contrib/hbwin/wapi_shellapi.c ! replaced struct = { 0 } with memset( &struct, 0, sizeof( struct ) ) Such BCC syntax does not clear the whole structure body in most of other C compilers.

  * src/pp/hbpp.c ! fixed compilation for compilers using "i64" to format long long numbers, thanks to Toninho for the information.